### PR TITLE
Update RegistryCI.jl by updating the .ci/Manifest.toml file (1.6.0)

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -172,9 +172,9 @@ version = "1.1.1"
 
 [[RegistryCI]]
 deps = ["Base64", "Dates", "GitHub", "HTTP", "JSON", "LibGit2", "LicenseCheck", "Pkg", "Printf", "Random", "RegistryTools", "SHA", "StringDistances", "TOML", "Test", "TimeZones", "VisualStringDistances"]
-git-tree-sha1 = "372c2cd3565ed6b32ae587f13109fc00359b6eca"
+git-tree-sha1 = "0e6dc27b444d77e3b7767586e1351a973253b012"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
-version = "6.8.10"
+version = "6.8.11"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]


### PR DESCRIPTION
This pull request updates RegistryCI.jl by updating the `.ci/Manifest.toml` file.