### PR TITLE
Update RegistryCI.jl by updating the .ci/Manifest.toml file (1.6.1)

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -185,9 +185,9 @@ version = "6.8.11"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
-git-tree-sha1 = "60522125b10a3b71b07677302c3aedd0b4363835"
+git-tree-sha1 = "400c6c8b167d61c301c7a4a9059e26ceaa1cc847"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
-version = "1.5.3"
+version = "1.5.4"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"


### PR DESCRIPTION
This pull request updates RegistryCI.jl by updating the `.ci/Manifest.toml` file.