### PR TITLE
Update RegistryCI.jl by updating the .ci/Manifest.toml file (1.5.3)

### DIFF
--- a/.ci/Manifest.1.5.3.toml
+++ b/.ci/Manifest.1.5.3.toml
@@ -179,9 +179,9 @@ version = "1.1.1"
 
 [[RegistryCI]]
 deps = ["Base64", "Dates", "GitHub", "HTTP", "JSON", "LibGit2", "LicenseCheck", "Pkg", "Printf", "Random", "RegistryTools", "SHA", "StringDistances", "TOML", "Tar", "Test", "TimeZones", "VisualStringDistances"]
-git-tree-sha1 = "f7d86d9710492f17fa14173f1c6164632ce38cc1"
+git-tree-sha1 = "12a0edd41a717fd654ed5037738e0f97c5a0308c"
 uuid = "0c95cc5f-2f7e-43fe-82dd-79dbcba86b32"
-version = "7.0.1"
+version = "7.0.2"
 
 [[RegistryTools]]
 deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]


### PR DESCRIPTION
This pull request updates RegistryCI.jl by updating the `.ci/Manifest.toml` file.